### PR TITLE
Apple Music reconnect flow + e2e failure test

### DIFF
--- a/e2e/playlist-apple-failure.spec.ts
+++ b/e2e/playlist-apple-failure.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { fixturePosts, fixtureUsers } from './support/cassette-fixtures';
+import { mockCassetteApp } from './support/mock-cassette-app';
+
+test('shows a generic error when Apple playlist creation fails after auth', async ({ page }) => {
+  await page.addInitScript(() => {
+    let isAuthorized = false;
+
+    Object.defineProperty(window, 'MusicKit', {
+      configurable: true,
+      value: {
+        configure: async () => undefined,
+        getInstance: () => ({
+          authorize: async () => {
+            isAuthorized = true;
+            return 'apple-user-token';
+          },
+          unauthorize: async () => {
+            isAuthorized = false;
+          },
+          get isAuthorized() {
+            return isAuthorized;
+          },
+        }),
+      },
+    });
+  });
+
+  await mockCassetteApp(page, {
+    currentUser: fixtureUsers.member,
+    posts: [fixturePosts.playlistSource],
+    musicConnectionsByUserId: {
+      [fixtureUsers.member.id]: ['Spotify'],
+    },
+  });
+
+  await page.route('**/api/v1/convert/createPlaylist', async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'Failed to create playlist',
+      }),
+    });
+  });
+
+  await page.goto('/post/post-source-playlist');
+  await page.getByTestId('playlist-convert-appleMusic').click();
+
+  await expect(page.locator('main')).toContainText('Failed to create playlist');
+  await expect(page.getByRole('button', { name: /Reconnect Apple Music|Connect Apple Music/ })).toHaveCount(0);
+  await expect
+    .poll(async () => page.evaluate(() => sessionStorage.getItem('cassette_pending_action')))
+    .toBeNull();
+});

--- a/src/components/features/entity/playlist-streaming-links.tsx
+++ b/src/components/features/entity/playlist-streaming-links.tsx
@@ -38,8 +38,11 @@ interface PlaylistStreamingLinksProps {
 interface CreationStatus {
   platform: PlatformKey;
   loading: boolean;
+  loadingMessage?: string;
   result?: CreatePlaylistResponse;
   error?: string;
+  requiresReconnect?: boolean;
+  actionLabel?: string;
 }
 
 const PLATFORMS: Array<PlatformKey> = ['spotify', 'appleMusic'];
@@ -114,6 +117,81 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
     };
   }, [isAuthenticated, playlistId, playlistTrackCount, postId, resolvedSourceUrl, sourcePlatformKey]);
 
+  const setAppleMusicReconnectState = React.useCallback((message: string, actionLabel: string) => {
+    setCreationStatus({
+      platform: 'appleMusic',
+      loading: false,
+      error: message,
+      requiresReconnect: true,
+      actionLabel,
+    });
+  }, []);
+
+  const createPlaylistOnPlatform = React.useCallback(async (platform: PlatformKey) => {
+    const serviceName = streamingServices[platform]?.name || platform;
+    setCreationStatus({
+      platform,
+      loading: true,
+      loadingMessage: `Creating playlist on ${serviceName}...`,
+    });
+
+    const result = await apiService.createPlaylist(playlistId, platform.toLowerCase(), postId);
+    pendingActionService.clear();
+    setCreationStatus({ platform, loading: false, result });
+  }, [playlistId, postId]);
+
+  const connectAppleMusicAndCreatePlaylist = React.useCallback(async (actionLabel = 'Reconnect Apple Music') => {
+    const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
+
+    pendingActionService.save(
+      pendingActionService.createPlaylistAction('appleMusic', playlistId, currentUrl)
+    );
+    setCreationStatus({
+      platform: 'appleMusic',
+      loading: true,
+      loadingMessage: 'Connecting to Apple Music...',
+    });
+
+    try {
+      const success = await platformConnectService.connectAppleMusic(currentUrl);
+      if (!success) {
+        setAppleMusicReconnectState('Failed to connect to Apple Music. Please try again.', actionLabel);
+        return;
+      }
+    } catch (error) {
+      if (error instanceof ApiError && error.requiresReauth) {
+        setAppleMusicReconnectState('Your Apple Music connection expired. Reconnect to continue.', 'Reconnect Apple Music');
+        return;
+      }
+
+      setCreationStatus({
+        platform: 'appleMusic',
+        loading: false,
+        error: error instanceof Error ? error.message : 'Failed to connect to Apple Music. Please try again.',
+        requiresReconnect: true,
+        actionLabel,
+      });
+      return;
+    }
+
+    pendingActionService.clear();
+
+    try {
+      await createPlaylistOnPlatform('appleMusic');
+    } catch (error) {
+      if (error instanceof ApiError && error.requiresReauth) {
+        setAppleMusicReconnectState('Your Apple Music connection expired. Reconnect to continue.', 'Reconnect Apple Music');
+        return;
+      }
+
+      setCreationStatus({
+        platform: 'appleMusic',
+        loading: false,
+        error: error instanceof Error ? error.message : 'Failed to create playlist',
+      });
+    }
+  }, [createPlaylistOnPlatform, playlistId, setAppleMusicReconnectState]);
+
   const handleCreatePlaylist = React.useCallback(async (platform: PlatformKey) => {
     const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
     const normalizedTarget = platform === 'appleMusic' ? 'apple' : platform;
@@ -153,7 +231,11 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
     }
 
     // Case 2: User logged in - check if they have platform connection
-    setCreationStatus({ platform, loading: true });
+    setCreationStatus({
+      platform,
+      loading: true,
+      loadingMessage: `Creating playlist on ${streamingServices[platform]?.name || platform}...`,
+    });
     setShowFailedTracks(false);
 
     try {
@@ -186,20 +268,7 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
           await platformConnectService.connectSpotify(currentUrl);
           return; // Will redirect to Spotify
         } else if (platform === 'appleMusic') {
-          // Apple Music uses modal-based auth (no redirect)
-          const success = await platformConnectService.connectAppleMusic(currentUrl);
-          if (success) {
-            // Connected successfully, now create the playlist
-            pendingActionService.clear();
-            const result = await apiService.createPlaylist(playlistId, platform.toLowerCase(), postId);
-            setCreationStatus({ platform, loading: false, result });
-          } else {
-            setCreationStatus({
-              platform,
-              loading: false,
-              error: 'Failed to connect to Apple Music. Please try again.',
-            });
-          }
+          await connectAppleMusicAndCreatePlaylist('Connect Apple Music');
           return;
         } else if (platform === 'deezer') {
           setCreationStatus({
@@ -212,37 +281,10 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
       }
 
       // Case 3: Has connection - create playlist directly
-      const result = await apiService.createPlaylist(playlistId, platform.toLowerCase(), postId);
-      pendingActionService.clear();
-      setCreationStatus({ platform, loading: false, result });
+      await createPlaylistOnPlatform(platform);
     } catch (error) {
-      // Check if this is an auth error requiring re-authentication
       if (error instanceof ApiError && error.requiresReauth && platform === 'appleMusic') {
-        // Clear the old connection and trigger re-auth flow
-        pendingActionService.save(
-          pendingActionService.createPlaylistAction(platform, playlistId, currentUrl)
-        );
-        const success = await platformConnectService.connectAppleMusic(currentUrl);
-        if (success) {
-          // Reconnected successfully, retry the playlist creation
-          pendingActionService.clear();
-          try {
-            const retryResult = await apiService.createPlaylist(playlistId, platform.toLowerCase(), postId);
-            setCreationStatus({ platform, loading: false, result: retryResult });
-          } catch (retryError) {
-            setCreationStatus({
-              platform,
-              loading: false,
-              error: retryError instanceof Error ? retryError.message : 'Failed to create playlist after reconnecting',
-            });
-          }
-        } else {
-          setCreationStatus({
-            platform,
-            loading: false,
-            error: 'Please reconnect your Apple Music account to continue.',
-          });
-        }
+        setAppleMusicReconnectState('Your Apple Music connection expired. Reconnect to continue.', 'Reconnect Apple Music');
         return;
       }
 
@@ -252,7 +294,17 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
         error: error instanceof Error ? error.message : 'Failed to create playlist',
       });
     }
-  }, [buildPlaylistAnalyticsProps, isAuthenticated, playlistId, postId, resolvedSourceUrl, sourcePlatformKey]);
+  }, [
+    buildPlaylistAnalyticsProps,
+    connectAppleMusicAndCreatePlaylist,
+    createPlaylistOnPlatform,
+    isAuthenticated,
+    playlistId,
+    postId,
+    resolvedSourceUrl,
+    setAppleMusicReconnectState,
+    sourcePlatformKey,
+  ]);
 
   useEffect(() => {
     if (!isAuthenticated || creationStatus || autoResumeAttemptedRef.current) {
@@ -275,8 +327,24 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
     }
 
     autoResumeAttemptedRef.current = true;
+
+    if (pendingAction.platform === 'appleMusic') {
+      setAppleMusicReconnectState('Connect Apple Music to continue converting this playlist.', 'Connect Apple Music');
+      return;
+    }
+
     void handleCreatePlaylist(pendingAction.platform);
-  }, [creationStatus, handleCreatePlaylist, isAuthenticated, playlistId]);
+  }, [creationStatus, handleCreatePlaylist, isAuthenticated, playlistId, setAppleMusicReconnectState]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    void platformConnectService.preloadAppleMusic().catch((error) => {
+      console.warn('Apple Music preload failed:', error);
+    });
+  }, [isAuthenticated]);
 
   // Save pending action before navigating to auth pages
   const handleAuthNavigate = () => {
@@ -299,7 +367,9 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
         <div className="mt-4 p-4 rounded-xl bg-info/10 border border-info/20">
           <div className="flex items-center gap-2 text-info-text">
             <Loader2 className="w-4 h-4 animate-spin" />
-            <span className="text-sm font-medium">Creating playlist on {serviceName}...</span>
+            <span className="text-sm font-medium">
+              {creationStatus.loadingMessage || `Creating playlist on ${serviceName}...`}
+            </span>
           </div>
         </div>
       );
@@ -312,6 +382,26 @@ export const PlaylistStreamingLinks: React.FC<PlaylistStreamingLinksProps> = ({
             <AlertCircle className="w-4 h-4" />
             <span className="text-sm font-medium">{creationStatus.error}</span>
           </div>
+          {creationStatus.requiresReconnect && creationStatus.platform === 'appleMusic' && (
+            <button
+              type="button"
+              onClick={() => void connectAppleMusicAndCreatePlaylist(creationStatus.actionLabel || 'Reconnect Apple Music')}
+              className={cn(
+                'mt-3 inline-flex items-center gap-2 px-4 py-2 rounded-full',
+                'bg-foreground text-background hover:opacity-90',
+                'text-sm font-medium transition-opacity w-fit cursor-pointer'
+              )}
+            >
+              <Image
+                src={streamingServices.appleMusic.icon}
+                alt={streamingServices.appleMusic.name}
+                width={16}
+                height={16}
+                className="object-contain"
+              />
+              <span>{creationStatus.actionLabel || 'Reconnect Apple Music'}</span>
+            </button>
+          )}
         </div>
       );
     }


### PR DESCRIPTION
Add explicit Apple Music reconnect handling and UI, plus an end-to-end test for Apple playlist creation failures.

- Add e2e/playlist-apple-failure.spec.ts: Playwright test that mocks MusicKit, simulates a 500 from createPlaylist API, and asserts a generic error is shown and no connect/reconnect button is present, and pending actions are cleared.
- Refactor src/components/features/entity/playlist-streaming-links.tsx:
  - Extend CreationStatus with loadingMessage, requiresReconnect, and actionLabel.
  - Introduce helpers: createPlaylistOnPlatform, connectAppleMusicAndCreatePlaylist, setAppleMusicReconnectState to centralize Apple Music connect/retry logic and pending-action management.
  - Use loadingMessage for improved loading UI text and show a contextual reconnect button when reauth is required.
  - Simplify handleCreatePlaylist to reuse the new helpers and handle reauth cases by prompting reconnect with a clear message.
  - Preload Apple Music when authenticated to improve UX.

These changes consolidate Apple Music auth/retry flows, improve user-facing messages, and add a test to ensure graceful handling of server-side playlist creation failures.