### PR TITLE
Render correct account badges for liked posts

### DIFF
--- a/e2e/profile-tabs.spec.ts
+++ b/e2e/profile-tabs.spec.ts
@@ -138,6 +138,31 @@ test.describe('profile tabs', () => {
     await expect(page.getByRole('main').last()).toContainText('No items to display');
   });
 
+  test('uses liked post owner badges instead of the profile owner badge', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    await mockCassetteApp(page, {
+      currentUser: {
+        ...fixtureUsers.member,
+        accountType: 'CassetteTeam',
+      },
+      posts: [
+        {
+          ...fixturePosts.publicTrack,
+          likedByCurrentUser: true,
+        },
+      ],
+    });
+
+    await page.goto('/profile/miagroove?tab=liked');
+    await expect(page).toHaveURL(/\/profile\/miagroove\?tab=liked$/);
+
+    const content = page.locator('[data-testid="profile-content-pane"]:visible').first();
+    const likedPost = content.locator('a[href^="/post/post-public-track"]').first();
+    await expect(likedPost).toContainText('@djaurora');
+    await expect(likedPost.getByAltText('Cassette Team')).toHaveCount(0);
+  });
+
   test('auto-selects the first non-empty tab when playlists are empty', async ({ page }) => {
     await mockCassetteApp(page, {
       currentUser: fixtureUsers.member,

--- a/e2e/support/mock-cassette-app.ts
+++ b/e2e/support/mock-cassette-app.ts
@@ -111,22 +111,27 @@ const toProfileBio = (user: FixtureUser, state: MockState) => ({
   accountType: user.accountType ?? null,
 });
 
-const toActivityItem = (post: FixturePost) => ({
-  postId: post.postId,
-  redirectPostId: post.postId,
-  isRepost: false,
-  elementType: post.elementType,
-  title: post.title,
-  description: post.description || '',
-  username: post.ownerUsername || '',
-  userId: post.ownerId || '',
-  createdAt: post.createdAt || FIXTURE_TIMESTAMP,
-  likeCount: post.likeCount || 0,
-  likedByCurrentUser: post.likedByCurrentUser || false,
-  commentsEnabled: post.commentsEnabled ?? true,
-  privacy: post.privacy || 'public',
-  conversionSuccessCount: post.conversionSuccessCount || 0,
-});
+const toActivityItem = (post: FixturePost, state: MockState) => {
+  const owner = post.ownerId ? state.usersById.get(post.ownerId) : undefined;
+
+  return {
+    postId: post.postId,
+    redirectPostId: post.postId,
+    isRepost: false,
+    elementType: post.elementType,
+    title: post.title,
+    description: post.description || '',
+    username: post.ownerUsername || '',
+    userId: post.ownerId || '',
+    createdAt: post.createdAt || FIXTURE_TIMESTAMP,
+    likeCount: post.likeCount || 0,
+    likedByCurrentUser: post.likedByCurrentUser || false,
+    commentsEnabled: post.commentsEnabled ?? true,
+    privacy: post.privacy || 'public',
+    conversionSuccessCount: post.conversionSuccessCount || 0,
+    accountType: owner?.accountType ?? null,
+  };
+};
 
 const toPostByIdResponse = (post: FixturePost) => ({
   success: true,
@@ -662,7 +667,7 @@ export async function mockCassetteApp(page: Page, options: MockCassetteOptions =
       const currentUser = getCurrentUserOrThrow(state);
       const items = Array.from(state.postsById.values()).filter((post) => post.ownerId === currentUser.id);
       return json(route, {
-        items: items.map(toActivityItem),
+        items: items.map((post) => toActivityItem(post, state)),
         page: 1,
         pageSize: Number(url.searchParams.get('pageSize') || 20),
         totalItems: items.length,
@@ -695,7 +700,7 @@ export async function mockCassetteApp(page: Page, options: MockCassetteOptions =
       });
 
       return json(route, {
-        items: items.slice(0, pageSize).map(toActivityItem),
+        items: items.slice(0, pageSize).map((post) => toActivityItem(post, state)),
         page: Number(url.searchParams.get('page') || 1),
         pageSize,
         totalItems: items.length,
@@ -704,12 +709,19 @@ export async function mockCassetteApp(page: Page, options: MockCassetteOptions =
     }
 
     if (/^\/api\/v1\/social\/users\/[^/]+\/liked-posts$/.test(pathname) && method === 'GET') {
+      const userId = pathname.split('/')[5] || '';
+      const user = state.usersById.get(userId);
+      const pageSize = Number(url.searchParams.get('pageSize') || 20);
+      const items = user && state.currentUser?.id === user.id
+        ? Array.from(state.postsById.values()).filter((post) => post.likedByCurrentUser)
+        : [];
+
       return json(route, {
-        items: [],
+        items: items.slice(0, pageSize).map((post) => toActivityItem(post, state)),
         page: Number(url.searchParams.get('page') || 1),
-        pageSize: Number(url.searchParams.get('pageSize') || 20),
-        totalItems: 0,
-        totalPages: 0,
+        pageSize,
+        totalItems: items.length,
+        totalPages: items.length > 0 ? 1 : 0,
       });
     }
 

--- a/src/app/(sidebar)/profile/[username]/page.tsx
+++ b/src/app/(sidebar)/profile/[username]/page.tsx
@@ -395,6 +395,7 @@ export default function ProfilePage() {
                 onLoadMore={loadMore}
                 hasMore={allActivityPosts.length < totalItems}
                 ownerAccountType={userBio?.accountType}
+                ownerUsername={userBio?.username}
                 isCurrentUser={isCurrentUser}
                 currentUserId={user?.id}
               />
@@ -437,6 +438,7 @@ export default function ProfilePage() {
                 onLoadMore={loadMore}
                 hasMore={allActivityPosts.length < totalItems}
                 ownerAccountType={userBio?.accountType}
+                ownerUsername={userBio?.username}
                 isCurrentUser={isCurrentUser}
                 currentUserId={user?.id}
               />

--- a/src/components/features/profile/profile-activity.tsx
+++ b/src/components/features/profile/profile-activity.tsx
@@ -25,7 +25,8 @@ interface ProfileActivityProps {
   isLoading?: boolean;
   onLoadMore?: () => void;
   hasMore?: boolean;
-  ownerAccountType?: AccountType | number;
+  ownerAccountType?: AccountType | number | string;
+  ownerUsername?: string;
   isCurrentUser?: boolean;
   currentUserId?: string;
 }
@@ -36,6 +37,7 @@ export function ProfileActivity({
   onLoadMore,
   hasMore = false,
   ownerAccountType,
+  ownerUsername,
   isCurrentUser = false,
   currentUserId
 }: ProfileActivityProps) {
@@ -70,7 +72,8 @@ export function ProfileActivity({
             <ActivityPostItem
               key={post.postId}
               post={post}
-              accountType={ownerAccountType}
+              ownerAccountType={ownerAccountType}
+              ownerUsername={ownerUsername}
               isOwnPost={
                 isCurrentUser &&
                 !!currentUserId &&
@@ -96,7 +99,17 @@ export function ProfileActivity({
   );
 }
 
-function ActivityPostItem({ post, accountType, isOwnPost = false }: { post: ActivityPost; accountType?: AccountType | number; isOwnPost?: boolean }) {
+function ActivityPostItem({
+  post,
+  ownerAccountType,
+  ownerUsername,
+  isOwnPost = false,
+}: {
+  post: ActivityPost;
+  ownerAccountType?: AccountType | number | string;
+  ownerUsername?: string;
+  isOwnPost?: boolean;
+}) {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -143,6 +156,14 @@ function ActivityPostItem({ post, accountType, isOwnPost = false }: { post: Acti
       post.username
     )
     : post.username;
+  const ownerAccountTypeApplies =
+    !!ownerUsername && sourceUsername.toLowerCase() === ownerUsername.toLowerCase();
+  const sourceAccountType = post.isRepost
+    ? post.originalPostOwnerAccountType
+    : post.accountType;
+  const displayedAccountType =
+    sourceAccountType ?? (ownerAccountTypeApplies ? ownerAccountType : undefined);
+
   // Only use description if it's a non-empty user-provided value
   const hasDescription = post.description && post.description.trim().length > 0;
   const detailText = hasDescription ? post.description : post.subtitle;
@@ -193,7 +214,7 @@ function ActivityPostItem({ post, accountType, isOwnPost = false }: { post: Acti
                   )}
                   <div className="flex items-center gap-1 text-[13px] text-muted-foreground min-w-0">
                     <span className="font-medium text-foreground/80 truncate">@{sourceUsername}</span>
-                    <VerificationBadge accountType={accountType} size="sm" />
+                    <VerificationBadge accountType={displayedAccountType} size="sm" />
                     {post.createdAt && (
                       <>
                         <span className="text-muted-foreground/50 flex-shrink-0">·</span>

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -17,6 +17,7 @@ interface ActivityItemPayload {
   originalPostOwnerUserId?: string | null;
   originalPostOwnerUsername?: string | null;
   originalPostOwnerAvatarUrl?: string | null;
+  originalPostOwnerAccountType?: string | number | null;
   elementType: string;
   title: string;
   name?: string;
@@ -56,6 +57,7 @@ interface ActivityItemPayload {
   likeCount?: number;
   likedByCurrentUser?: boolean;
   commentsEnabled?: boolean;
+  accountType?: string | number;
   [key: string]: unknown;
 }
 
@@ -469,6 +471,16 @@ export class ProfileService {
             pickString(itemObj, ['originalPostOwnerAvatarUrl', 'OriginalPostOwnerAvatarUrl']) ||
             (originalOwnerObj ? pickString(originalOwnerObj, ['avatarUrl', 'AvatarUrl', 'profilePicture', 'ProfilePicture']) : undefined) ||
             null,
+          originalPostOwnerAccountType:
+            pickString(itemObj, ['originalPostOwnerAccountType', 'OriginalPostOwnerAccountType']) ??
+            pickNumber(itemObj, ['originalPostOwnerAccountType', 'OriginalPostOwnerAccountType']) ??
+            (originalOwnerObj
+              ? (
+                  pickString(originalOwnerObj, ['accountType', 'AccountType']) ??
+                  pickNumber(originalOwnerObj, ['accountType', 'AccountType'])
+                )
+              : undefined) ??
+            null,
           elementType:
             pickString(itemObj, ['elementType', 'ElementType']) ||
             'Track',
@@ -484,6 +496,9 @@ export class ProfileService {
           likeCount: pickNumber(itemObj, ['likeCount', 'LikeCount']),
           likedByCurrentUser: pickBoolean(itemObj, ['likedByCurrentUser', 'LikedByCurrentUser']),
           commentsEnabled: pickBoolean(itemObj, ['commentsEnabled', 'CommentsEnabled']),
+          accountType:
+            pickString(itemObj, ['accountType', 'AccountType']) ??
+            pickNumber(itemObj, ['accountType', 'AccountType']),
         };
       });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,7 @@ export interface ActivityPost {
   originalPostOwnerUserId?: string | null;
   originalPostOwnerUsername?: string | null;
   originalPostOwnerAvatarUrl?: string | null;
+  originalPostOwnerAccountType?: AccountType | number | string | null;
   elementType: string;
   title: string;
   subtitle?: string;
@@ -63,6 +64,7 @@ export interface ActivityPost {
   likeCount?: number;
   likedByCurrentUser?: boolean;
   commentsEnabled?: boolean;
+  accountType?: AccountType | number | string;
 }
 
 export interface PaginatedActivityResponse {


### PR DESCRIPTION
Ensure verification badges reflect the actual post owner (not the profile owner) for liked posts. Add ownerUsername prop to ProfileActivity and use it in ActivityPostItem to decide which accountType to display; compute displayedAccountType from the post's source owner or the profile owner when appropriate. Extend ProfileService parsing and ActivityPost types to include accountType and originalPostOwnerAccountType. Update the mock cassette app to populate accountType in activity items and return liked-posts for the current user. Add an end-to-end test that verifies liked posts show the post owner's badge instead of the profile owner badge.