### PR TITLE
Add internal Explore snapshots UI and API

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve:e2e": "next build && next start -H 127.0.0.1 -p 3101",
     "lint": "next lint",
     "test:e2e": "playwright test",
-    "test:unit": "tsc -p tsconfig.unit-tests.json && node --test .unit-test-dist/utils/__tests__/platform-normalization.test.js",
+    "test:unit": "rm -rf .unit-test-dist && tsc -p tsconfig.unit-tests.json && node --test $(find .unit-test-dist -name '*.test.js' -print)",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "test:analytics": "rm -rf .analytics-test-dist && tsc -p tsconfig.analytics-tests.json && node --test $(find .analytics-test-dist -name '*.test.js' -print)",
     "release:draft": "bash scripts/release-draft.sh",

--- a/src/app/(sidebar)/internal/_components/__tests__/explore-snapshot-utils.test.ts
+++ b/src/app/(sidebar)/internal/_components/__tests__/explore-snapshot-utils.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  formatScore,
+  pickDefaultSnapshotId,
+  snapshotStatusTone,
+  scoreEntries,
+  maxAbsValue,
+  barWidthPercent,
+} from '../explore-snapshot-utils';
+
+test('formatScore renders 3 decimal places and handles missing values', () => {
+  assert.equal(formatScore(0.5), '0.500');
+  assert.equal(formatScore(-0.1), '-0.100');
+  assert.equal(formatScore(1.23456), '1.235');
+  assert.equal(formatScore(null), '—');
+  assert.equal(formatScore(undefined), '—');
+  assert.equal(formatScore(Number.NaN), '—');
+});
+
+test('pickDefaultSnapshotId prefers the latest successful snapshot', () => {
+  const id = pickDefaultSnapshotId([
+    { snapshotId: 'exs_failed_newest', status: 'Failed', isLatestSuccessful: false },
+    { snapshotId: 'exs_success', status: 'Succeeded', isLatestSuccessful: true },
+    { snapshotId: 'exs_old', status: 'Succeeded', isLatestSuccessful: false },
+  ]);
+  assert.equal(id, 'exs_success');
+});
+
+test('pickDefaultSnapshotId falls back to first Succeeded, then newest, then null', () => {
+  // No flagged-latest: fall back to first Succeeded in the (newest-first) list.
+  assert.equal(
+    pickDefaultSnapshotId([
+      { snapshotId: 'exs_failed', status: 'Failed', isLatestSuccessful: false },
+      { snapshotId: 'exs_ok', status: 'Succeeded', isLatestSuccessful: false },
+    ]),
+    'exs_ok'
+  );
+  // No successful at all: fall back to the newest (first) row.
+  assert.equal(
+    pickDefaultSnapshotId([
+      { snapshotId: 'exs_failed_a', status: 'Failed', isLatestSuccessful: false },
+      { snapshotId: 'exs_failed_b', status: 'Failed', isLatestSuccessful: false },
+    ]),
+    'exs_failed_a'
+  );
+  assert.equal(pickDefaultSnapshotId([]), null);
+});
+
+test('snapshotStatusTone maps known statuses', () => {
+  assert.equal(snapshotStatusTone('Succeeded'), 'success');
+  assert.equal(snapshotStatusTone('Failed'), 'failed');
+  assert.equal(snapshotStatusTone('Generating'), 'pending');
+  assert.equal(snapshotStatusTone(null), 'pending');
+});
+
+test('scoreEntries sorts by descending magnitude', () => {
+  const entries = scoreEntries({ small: 0.1, big: -0.9, mid: 0.5 });
+  assert.deepEqual(
+    entries.map(([key]) => key),
+    ['big', 'mid', 'small']
+  );
+  assert.deepEqual(scoreEntries(null), []);
+});
+
+test('maxAbsValue spans multiple maps and barWidthPercent scales to it', () => {
+  const max = maxAbsValue({ a: 0.2 }, { b: -0.8 }, null);
+  assert.equal(max, 0.8);
+  assert.equal(barWidthPercent(0.8, max), 100);
+  assert.equal(barWidthPercent(0.4, max), 50);
+  assert.equal(barWidthPercent(0.4, 0), 0);
+});

--- a/src/app/(sidebar)/internal/_components/explore-score-breakdown.tsx
+++ b/src/app/(sidebar)/internal/_components/explore-score-breakdown.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { ChevronDown, Code } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { InternalExploreSnapshotItem } from '@/types';
+import {
+  barWidthPercent,
+  formatDebugValue,
+  formatScore,
+  hasPlaylistFamily,
+  maxAbsValue,
+  scoreEntries,
+} from './explore-snapshot-utils';
+
+interface ExploreScoreBreakdownProps {
+  item: InternalExploreSnapshotItem;
+}
+
+type BarTone = 'component' | 'boost' | 'penalty';
+
+const TONE_BAR_CLASS: Record<BarTone, string> = {
+  component: 'bg-[hsl(var(--info))]',
+  boost: 'bg-[hsl(var(--success))]',
+  penalty: 'bg-destructive',
+};
+
+const TONE_VALUE_CLASS: Record<BarTone, string> = {
+  component: 'text-foreground',
+  boost: 'text-[hsl(var(--success))]',
+  penalty: 'text-destructive',
+};
+
+function BarRow({ label, value, tone, scale }: { label: string; value: number; tone: BarTone; scale: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-44 shrink-0 truncate font-mono text-[11px] text-muted-foreground" title={label}>
+        {label}
+      </span>
+      <div className="relative h-2 flex-1 overflow-hidden rounded bg-muted/50">
+        <div className={`h-full rounded ${TONE_BAR_CLASS[tone]}`} style={{ width: `${barWidthPercent(value, scale)}%` }} />
+      </div>
+      <span className={`w-16 shrink-0 text-right font-mono text-[11px] tabular-nums ${TONE_VALUE_CLASS[tone]}`}>
+        {formatScore(value)}
+      </span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+function KeyValueList({ data }: { data: Record<string, unknown> }) {
+  const entries = Object.entries(data);
+  if (!entries.length) {
+    return <p className="text-[11px] text-muted-foreground">None</p>;
+  }
+  return (
+    <div className="grid gap-1">
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex items-baseline gap-2">
+          <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{key}</span>
+          <span className="break-all font-mono text-[11px]">{formatDebugValue(value)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ExploreScoreBreakdown({ item }: ExploreScoreBreakdownProps) {
+  const [showRawJson, setShowRawJson] = useState(false);
+
+  // Scale every bar against the largest magnitude across all three maps so they're directly comparable.
+  const scale = useMemo(
+    () => maxAbsValue(item.scoreComponents, item.boosts, item.penalties) || 1,
+    [item.scoreComponents, item.boosts, item.penalties]
+  );
+
+  const components = scoreEntries(item.scoreComponents);
+  const boosts = scoreEntries(item.boosts);
+  const penalties = scoreEntries(item.penalties);
+
+  const rawJson = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          scoreComponents: item.scoreComponents,
+          boosts: item.boosts,
+          penalties: item.penalties,
+          constraintNotes: item.constraintNotes ?? {},
+          candidateSources: item.candidateSources ?? {},
+        },
+        null,
+        2
+      ),
+    [item]
+  );
+
+  return (
+    <div className="grid gap-5 rounded-lg border bg-muted/20 p-4 lg:grid-cols-2">
+      {/* Left column: scores as bars */}
+      <div className="space-y-4">
+        <Section title={`Score components (${components.length})`}>
+          {components.length ? (
+            <div className="space-y-1">
+              {components.map(([label, value]) => (
+                <BarRow key={label} label={label} value={value} tone="component" scale={scale} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-[11px] text-muted-foreground">None</p>
+          )}
+        </Section>
+
+        {boosts.length > 0 && (
+          <Section title={`Boosts (${boosts.length})`}>
+            <div className="space-y-1">
+              {boosts.map(([label, value]) => (
+                <BarRow key={label} label={label} value={value} tone="boost" scale={scale} />
+              ))}
+            </div>
+          </Section>
+        )}
+
+        <Section title={`Penalties (${penalties.length})`}>
+          {penalties.length ? (
+            <div className="space-y-1">
+              {penalties.map(([label, value]) => (
+                <BarRow key={label} label={label} value={value} tone="penalty" scale={scale} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-[11px] text-muted-foreground">None</p>
+          )}
+        </Section>
+      </div>
+
+      {/* Right column: debug metadata */}
+      <div className="space-y-4">
+        <Section title="Constraint notes">
+          <KeyValueList data={item.constraintNotes ?? {}} />
+        </Section>
+
+        <Section title="Candidate sources">
+          <KeyValueList data={item.candidateSources ?? {}} />
+        </Section>
+
+        {hasPlaylistFamily(item) && (
+          <Section title="Playlist family">
+            <KeyValueList
+              data={{
+                familyKey: item.playlistFamilyKey,
+                normalizedTitle: item.playlistTitleNormalized,
+                confidence: item.playlistFamilyConfidence,
+                reason: item.playlistFamilyReason,
+                isGeneric: item.isGenericPlaylistFamily,
+              }}
+            />
+          </Section>
+        )}
+
+        <Collapsible open={showRawJson} onOpenChange={setShowRawJson}>
+          <CollapsibleTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-full justify-between gap-2 px-2 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              <div className="flex items-center gap-1.5">
+                <Code className="h-3 w-3" />
+                Raw JSON
+              </div>
+              <ChevronDown className={`h-3 w-3 transition-transform ${showRawJson ? 'rotate-180' : ''}`} />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <ScrollArea className="mt-1.5 max-h-[280px]">
+              <pre className="whitespace-pre-wrap break-all rounded-lg border bg-muted/30 p-3 text-[11px] font-mono leading-relaxed">
+                {rawJson}
+              </pre>
+            </ScrollArea>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(sidebar)/internal/_components/explore-snapshot-items-table.tsx
+++ b/src/app/(sidebar)/internal/_components/explore-snapshot-items-table.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { Fragment, useState } from 'react';
+import { ChevronRight, ListMusic } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import type { InternalExploreSnapshotItem } from '@/types';
+import { formatDate } from './internal-utils';
+import { formatScore } from './explore-snapshot-utils';
+import { ExploreScoreBreakdown } from './explore-score-breakdown';
+import { EmptyState } from './empty-state';
+
+interface ExploreSnapshotItemsTableProps {
+  items: InternalExploreSnapshotItem[];
+  isLoading: boolean;
+}
+
+const COLUMN_COUNT = 12;
+
+function availabilityBadgeClass(isAvailable: boolean) {
+  return isAvailable
+    ? 'bg-[hsl(var(--success))]/10 text-[hsl(var(--success))] border-[hsl(var(--success))]/20'
+    : 'bg-destructive/10 text-destructive border-destructive/20';
+}
+
+function TableSkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <TableRow key={i}>
+          <TableCell colSpan={COLUMN_COUNT}>
+            <div className="h-5 w-full animate-pulse rounded bg-muted/50" />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+export function ExploreSnapshotItemsTable({ items, isLoading }: ExploreSnapshotItemsTableProps) {
+  const [expandedRank, setExpandedRank] = useState<number | null>(null);
+
+  const toggle = (rank: number) => setExpandedRank((current) => (current === rank ? null : rank));
+
+  if (!isLoading && !items.length) {
+    return (
+      <EmptyState
+        icon={ListMusic}
+        title="No ranked items"
+        description="This snapshot has no stored items to inspect."
+      />
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-8" />
+            <TableHead className="w-12 text-right">#</TableHead>
+            <TableHead className="whitespace-nowrap">Type</TableHead>
+            <TableHead className="whitespace-nowrap">Title</TableHead>
+            <TableHead className="whitespace-nowrap">Creator</TableHead>
+            <TableHead className="whitespace-nowrap">Availability</TableHead>
+            <TableHead className="whitespace-nowrap">Post ID</TableHead>
+            <TableHead className="whitespace-nowrap">Music ID</TableHead>
+            <TableHead className="whitespace-nowrap">Created</TableHead>
+            <TableHead className="whitespace-nowrap text-right">Raw</TableHead>
+            <TableHead className="whitespace-nowrap text-right">Final</TableHead>
+            <TableHead className="whitespace-nowrap">Rank reason</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading ? (
+            <TableSkeletonRows />
+          ) : (
+            items.map((item) => {
+              const isExpanded = expandedRank === item.rank;
+              return (
+                <Fragment key={item.rank}>
+                  <TableRow
+                    className={`cursor-pointer transition-colors ${
+                      isExpanded ? 'bg-primary/5' : 'hover:bg-muted/40'
+                    }`}
+                    onClick={() => toggle(item.rank)}
+                  >
+                    <TableCell className="py-1.5">
+                      <ChevronRight
+                        className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${
+                          isExpanded ? 'rotate-90' : ''
+                        }`}
+                      />
+                    </TableCell>
+                    <TableCell className="py-1.5 text-right font-mono text-xs tabular-nums">{item.rank}</TableCell>
+                    <TableCell className="py-1.5">
+                      <Badge variant="outline" className="text-[10px]">
+                        {item.elementType}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="max-w-[220px] py-1.5">
+                      <div className="truncate text-xs font-medium" title={item.title ?? undefined}>
+                        {item.title || <span className="text-muted-foreground">Untitled</span>}
+                      </div>
+                      {item.subtitle && (
+                        <div className="truncate text-[11px] text-muted-foreground" title={item.subtitle}>
+                          {item.subtitle}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell className="py-1.5">
+                      <span className="text-xs">
+                        {item.creatorUsername || <span className="text-muted-foreground">—</span>}
+                      </span>
+                    </TableCell>
+                    <TableCell className="py-1.5">
+                      <Badge
+                        variant="outline"
+                        className={`text-[10px] font-medium ${availabilityBadgeClass(item.isAvailable)}`}
+                        title={item.currentPrivacy ? `privacy: ${item.currentPrivacy}` : undefined}
+                      >
+                        {item.availability}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="py-1.5">
+                      <span className="block max-w-[130px] truncate font-mono text-[11px] text-muted-foreground" title={item.postId}>
+                        {item.postId}
+                      </span>
+                    </TableCell>
+                    <TableCell className="py-1.5">
+                      <span className="block max-w-[130px] truncate font-mono text-[11px] text-muted-foreground" title={item.musicElementId}>
+                        {item.musicElementId}
+                      </span>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap py-1.5 text-[11px] text-muted-foreground">
+                      {formatDate(item.createdAtUtc)}
+                    </TableCell>
+                    <TableCell className="py-1.5 text-right font-mono text-xs tabular-nums text-muted-foreground">
+                      {formatScore(item.rawScore)}
+                    </TableCell>
+                    <TableCell className="py-1.5 text-right font-mono text-xs font-semibold tabular-nums">
+                      {formatScore(item.finalScore)}
+                    </TableCell>
+                    <TableCell className="max-w-[180px] py-1.5">
+                      <span className="block truncate text-[11px] text-muted-foreground" title={item.rankReason}>
+                        {item.rankReason || '—'}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                  {isExpanded && (
+                    <TableRow className="hover:bg-transparent">
+                      <TableCell colSpan={COLUMN_COUNT} className="bg-muted/10 p-3">
+                        <ExploreScoreBreakdown item={item} />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(sidebar)/internal/_components/explore-snapshot-utils.ts
+++ b/src/app/(sidebar)/internal/_components/explore-snapshot-utils.ts
@@ -1,0 +1,84 @@
+// Pure helpers for the internal Explore snapshot inspection tab.
+// Kept free of React/runtime imports so they can be unit-tested with node:test.
+import type {
+  InternalExploreSnapshotSummary,
+  InternalExploreSnapshotItem,
+} from '@/types';
+
+export const SNAPSHOT_DAYS_DEFAULT = 14;
+export const SNAPSHOT_ITEM_LIMIT = 50;
+
+export type SnapshotStatusTone = 'success' | 'failed' | 'pending';
+
+/** Format a score/score-component value to a fixed 3 decimal places (e.g. 0.5 → "0.500", -0.1 → "-0.100"). */
+export function formatScore(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return value.toFixed(3);
+}
+
+/**
+ * Choose the snapshot to select by default: the latest successful one, falling back to the first
+ * Succeeded row, then the newest row overall. Returns null for an empty list.
+ */
+export function pickDefaultSnapshotId(
+  snapshots: Pick<InternalExploreSnapshotSummary, 'snapshotId' | 'status' | 'isLatestSuccessful'>[]
+): string | null {
+  if (!snapshots.length) return null;
+  const latestSuccessful = snapshots.find((s) => s.isLatestSuccessful);
+  if (latestSuccessful) return latestSuccessful.snapshotId;
+  const firstSucceeded = snapshots.find((s) => s.status?.toLowerCase() === 'succeeded');
+  if (firstSucceeded) return firstSucceeded.snapshotId;
+  return snapshots[0].snapshotId;
+}
+
+/** Maps a snapshot status string to a visual tone for badges. */
+export function snapshotStatusTone(status: string | null | undefined): SnapshotStatusTone {
+  const normalized = (status ?? '').toLowerCase();
+  if (normalized === 'succeeded') return 'success';
+  if (normalized === 'failed') return 'failed';
+  return 'pending';
+}
+
+/** Sorted [key, value] entries of a numeric map, largest magnitude first, for compact bar rendering. */
+export function scoreEntries(map: Record<string, number> | null | undefined): [string, number][] {
+  if (!map) return [];
+  return Object.entries(map).sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]));
+}
+
+/** Largest absolute value across a set of numeric maps; used to scale horizontal bars consistently. */
+export function maxAbsValue(...maps: (Record<string, number> | null | undefined)[]): number {
+  let max = 0;
+  for (const map of maps) {
+    if (!map) continue;
+    for (const value of Object.values(map)) {
+      const abs = Math.abs(value);
+      if (abs > max) max = abs;
+    }
+  }
+  return max;
+}
+
+/** Bar width as a 0–100 percentage of the provided scale. */
+export function barWidthPercent(value: number, maxAbs: number): number {
+  if (!maxAbs || Number.isNaN(maxAbs)) return 0;
+  const pct = (Math.abs(value) / maxAbs) * 100;
+  if (pct < 0) return 0;
+  return pct > 100 ? 100 : pct;
+}
+
+/** True when a snapshot item carries playlist-family grouping metadata worth showing. */
+export function hasPlaylistFamily(item: InternalExploreSnapshotItem): boolean {
+  return Boolean(
+    item.playlistFamilyKey ||
+      item.playlistTitleNormalized ||
+      item.playlistFamilyReason ||
+      item.playlistFamilyConfidence != null
+  );
+}
+
+/** Render an arbitrary debug-metadata value (from constraint notes / candidate sources) as a short string. */
+export function formatDebugValue(value: unknown): string {
+  if (value == null) return '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}

--- a/src/app/(sidebar)/internal/_components/explore-snapshots-tab.tsx
+++ b/src/app/(sidebar)/internal/_components/explore-snapshots-tab.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Layers,
+  RefreshCw,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  Hash,
+  Database,
+  Clock,
+} from 'lucide-react';
+import { apiService } from '@/services/api';
+import type {
+  InternalExploreSnapshotSummary,
+  InternalExploreSnapshotItemsResponse,
+} from '@/types';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { formatDate } from './internal-utils';
+import {
+  SNAPSHOT_DAYS_DEFAULT,
+  SNAPSHOT_ITEM_LIMIT,
+  pickDefaultSnapshotId,
+  snapshotStatusTone,
+} from './explore-snapshot-utils';
+import { ExploreSnapshotItemsTable } from './explore-snapshot-items-table';
+import { EmptyState } from './empty-state';
+import { ErrorState } from './error-state';
+
+const DAY_RANGES = [7, 14, 30, 90];
+
+function statusBadgeClass(status: string) {
+  switch (snapshotStatusTone(status)) {
+    case 'success':
+      return 'bg-[hsl(var(--success))]/10 text-[hsl(var(--success))] border-[hsl(var(--success))]/20';
+    case 'failed':
+      return 'bg-destructive/10 text-destructive border-destructive/20';
+    default:
+      return 'bg-[hsl(var(--warning))]/10 text-[hsl(var(--warning))] border-[hsl(var(--warning))]/20';
+  }
+}
+
+/** Pull a numeric {Type: count} distribution out of the open-shaped validation metrics, if present. */
+function readContentTypeDistribution(
+  metrics: Record<string, unknown> | null | undefined
+): [string, number][] | null {
+  const dist = metrics?.['content_type_distribution'];
+  if (!dist || typeof dist !== 'object' || Array.isArray(dist)) return null;
+  const entries = Object.entries(dist as Record<string, unknown>).filter(
+    ([, value]) => typeof value === 'number'
+  ) as [string, number][];
+  return entries.length ? entries : null;
+}
+
+function SummaryStat({ icon: Icon, label, value }: { icon: React.ElementType; label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <div className="min-w-0">
+        <p className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</p>
+        <p className="truncate text-sm font-medium tabular-nums">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+export function ExploreSnapshotsTab() {
+  const [days, setDays] = useState(SNAPSHOT_DAYS_DEFAULT);
+  const [snapshots, setSnapshots] = useState<InternalExploreSnapshotSummary[]>([]);
+  const [snapshotsLoading, setSnapshotsLoading] = useState(false);
+  const [snapshotsError, setSnapshotsError] = useState<string | null>(null);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [userPickedId, setUserPickedId] = useState(false);
+
+  const [itemsResponse, setItemsResponse] = useState<InternalExploreSnapshotItemsResponse | null>(null);
+  const [itemsLoading, setItemsLoading] = useState(false);
+  const [itemsError, setItemsError] = useState<string | null>(null);
+
+  const loadSnapshots = useCallback(async () => {
+    setSnapshotsLoading(true);
+    setSnapshotsError(null);
+    try {
+      const response = await apiService.getInternalExploreSnapshots(days);
+      setSnapshots(response.items);
+    } catch (error) {
+      setSnapshotsError(error instanceof Error ? error.message : 'Failed to load snapshots');
+    } finally {
+      setSnapshotsLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    void loadSnapshots();
+  }, [loadSnapshots]);
+
+  // Default-select the latest successful snapshot until the user explicitly picks one.
+  useEffect(() => {
+    if (userPickedId) {
+      // Keep the user's selection only while it still exists in the list.
+      if (selectedId && snapshots.some((s) => s.snapshotId === selectedId)) return;
+    }
+    const next = pickDefaultSnapshotId(snapshots);
+    setSelectedId(next);
+    setUserPickedId(false);
+  }, [snapshots, userPickedId, selectedId]);
+
+  const loadItems = useCallback(async (snapshotId: string) => {
+    setItemsLoading(true);
+    setItemsError(null);
+    try {
+      const response = await apiService.getInternalExploreSnapshotItems(snapshotId, SNAPSHOT_ITEM_LIMIT);
+      setItemsResponse(response);
+    } catch (error) {
+      setItemsResponse(null);
+      setItemsError(error instanceof Error ? error.message : 'Failed to load snapshot items');
+    } finally {
+      setItemsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setItemsResponse(null);
+      return;
+    }
+    void loadItems(selectedId);
+  }, [selectedId, loadItems]);
+
+  const selectedSnapshot = useMemo(
+    () => snapshots.find((s) => s.snapshotId === selectedId) ?? null,
+    [snapshots, selectedId]
+  );
+
+  const distribution = readContentTypeDistribution(selectedSnapshot?.validationMetrics);
+
+  const handleSelect = (snapshotId: string) => {
+    setUserPickedId(true);
+    setSelectedId(snapshotId);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 xl:flex-row xl:items-start">
+      {/* Snapshot selector */}
+      <div className="xl:w-[320px] xl:shrink-0">
+        <Card>
+          <div className="flex items-center justify-between px-4 pt-4 pb-2">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10">
+                <Layers className="h-3.5 w-3.5 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold">Snapshots</h2>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              disabled={snapshotsLoading}
+              onClick={() => void loadSnapshots()}
+              title="Refresh"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${snapshotsLoading ? 'animate-spin' : ''}`} />
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-1 px-4 pb-3">
+            {DAY_RANGES.map((range) => (
+              <Button
+                key={range}
+                variant={days === range ? 'default' : 'outline'}
+                size="sm"
+                className="h-6 px-2 text-[11px]"
+                onClick={() => setDays(range)}
+              >
+                {range}d
+              </Button>
+            ))}
+          </div>
+
+          <CardContent className="pt-0">
+            {snapshotsError ? (
+              <ErrorState message={snapshotsError} onRetry={() => void loadSnapshots()} />
+            ) : snapshotsLoading && !snapshots.length ? (
+              <div className="space-y-2">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="h-16 animate-pulse rounded-lg bg-muted/40" />
+                ))}
+              </div>
+            ) : !snapshots.length ? (
+              <EmptyState
+                icon={Database}
+                title="No snapshots"
+                description={`No Explore snapshots generated in the last ${days} days.`}
+              />
+            ) : (
+              <div className="max-h-[calc(100vh-16rem)] space-y-1.5 overflow-y-auto no-scrollbar">
+                {snapshots.map((snapshot) => {
+                  const isSelected = snapshot.snapshotId === selectedId;
+                  const warnings = snapshot.validationWarnings.length;
+                  const fatals = snapshot.validationFatalErrors.length;
+                  return (
+                    <button
+                      key={snapshot.snapshotId}
+                      type="button"
+                      onClick={() => handleSelect(snapshot.snapshotId)}
+                      className={`w-full rounded-lg border p-2.5 text-left transition-all ${
+                        isSelected
+                          ? 'border-primary/30 bg-primary/5 ring-1 ring-primary/10'
+                          : 'hover:border-border/80 hover:bg-muted/30'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="flex items-center gap-1 text-xs font-medium">
+                          <Clock className="h-3 w-3 text-muted-foreground" />
+                          {formatDate(snapshot.generatedAtUtc)}
+                        </span>
+                        <Badge variant="outline" className={`text-[10px] ${statusBadgeClass(snapshot.status)}`}>
+                          {snapshot.status}
+                        </Badge>
+                      </div>
+                      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                        <span className="font-mono">{snapshot.algorithmVersion}</span>
+                        <span className="tabular-nums">
+                          {snapshot.candidateCount} cand · {snapshot.storedItemCount} items
+                        </span>
+                      </div>
+                      <div className="mt-1 flex flex-wrap items-center gap-1">
+                        {snapshot.isLatestSuccessful && (
+                          <Badge
+                            variant="outline"
+                            className="h-4 gap-0.5 px-1 text-[9px] bg-[hsl(var(--success))]/10 text-[hsl(var(--success))] border-[hsl(var(--success))]/20"
+                          >
+                            <CheckCircle2 className="h-2.5 w-2.5" /> Live
+                          </Badge>
+                        )}
+                        {fatals > 0 && (
+                          <Badge variant="outline" className="h-4 gap-0.5 px-1 text-[9px] bg-destructive/10 text-destructive border-destructive/20">
+                            <XCircle className="h-2.5 w-2.5" /> {fatals} fatal
+                          </Badge>
+                        )}
+                        {warnings > 0 && (
+                          <Badge variant="outline" className="h-4 gap-0.5 px-1 text-[9px] bg-[hsl(var(--warning))]/10 text-[hsl(var(--warning))] border-[hsl(var(--warning))]/20">
+                            <AlertTriangle className="h-2.5 w-2.5" /> {warnings} warn
+                          </Badge>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Selected snapshot detail + ranked items */}
+      <div className="min-w-0 flex-1">
+        <Card>
+          <CardContent className="space-y-4 p-4 md:p-6">
+            {!selectedSnapshot ? (
+              <EmptyState
+                icon={Layers}
+                title="No snapshot selected"
+                description="Pick a snapshot from the list to inspect its ranked items."
+              />
+            ) : (
+              <>
+                {/* Summary header */}
+                <div className="space-y-3 border-b pb-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-mono text-sm font-semibold">{selectedSnapshot.snapshotId}</span>
+                    <Badge variant="outline" className={`text-[10px] ${statusBadgeClass(selectedSnapshot.status)}`}>
+                      {selectedSnapshot.status}
+                    </Badge>
+                    {selectedSnapshot.isLatestSuccessful && (
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] bg-[hsl(var(--success))]/10 text-[hsl(var(--success))] border-[hsl(var(--success))]/20"
+                      >
+                        Live on Explore
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+                    <SummaryStat icon={Clock} label="Generated" value={formatDate(selectedSnapshot.generatedAtUtc)} />
+                    <SummaryStat icon={Hash} label="Algorithm" value={selectedSnapshot.algorithmVersion} />
+                    <SummaryStat icon={Database} label="Candidates" value={selectedSnapshot.candidateCount.toLocaleString()} />
+                    <SummaryStat icon={Layers} label="Items" value={selectedSnapshot.storedItemCount.toLocaleString()} />
+                    <SummaryStat icon={Hash} label="Seed" value={selectedSnapshot.seed || '—'} />
+                  </div>
+
+                  {selectedSnapshot.failureReason && (
+                    <div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-2.5">
+                      <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" />
+                      <p className="text-xs text-destructive">{selectedSnapshot.failureReason}</p>
+                    </div>
+                  )}
+
+                  {selectedSnapshot.validationFatalErrors.length > 0 && (
+                    <div className="space-y-1 rounded-md border border-destructive/20 bg-destructive/5 p-2.5">
+                      <p className="text-[11px] font-medium uppercase tracking-wider text-destructive">Fatal errors</p>
+                      {selectedSnapshot.validationFatalErrors.map((err, i) => (
+                        <p key={i} className="font-mono text-[11px] text-destructive">{err}</p>
+                      ))}
+                    </div>
+                  )}
+
+                  {selectedSnapshot.validationWarnings.length > 0 && (
+                    <div className="space-y-1 rounded-md border border-[hsl(var(--warning))]/20 bg-[hsl(var(--warning))]/5 p-2.5">
+                      <p className="text-[11px] font-medium uppercase tracking-wider text-[hsl(var(--warning))]">Warnings</p>
+                      {selectedSnapshot.validationWarnings.map((warn, i) => (
+                        <p key={i} className="font-mono text-[11px] text-[hsl(var(--warning))]">{warn}</p>
+                      ))}
+                    </div>
+                  )}
+
+                  {distribution && (
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                        Type distribution
+                      </span>
+                      {distribution.map(([type, count]) => (
+                        <Badge key={type} variant="secondary" className="text-[10px] tabular-nums">
+                          {type}: {count}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Ranked items */}
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">Ranked items</h3>
+                  {itemsResponse && (
+                    <span className="text-[11px] text-muted-foreground tabular-nums">
+                      Top {itemsResponse.returnedItemCount} of {itemsResponse.totalItemCount.toLocaleString()}
+                    </span>
+                  )}
+                </div>
+
+                {itemsError ? (
+                  <ErrorState message={itemsError} onRetry={() => selectedId && void loadItems(selectedId)} />
+                ) : (
+                  <ExploreSnapshotItemsTable items={itemsResponse?.items ?? []} isLoading={itemsLoading} />
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(sidebar)/internal/_components/internal-dashboard-shell.tsx
+++ b/src/app/(sidebar)/internal/_components/internal-dashboard-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { Users, AlertCircle, Link2, Shield } from 'lucide-react';
+import { Users, AlertCircle, Link2, Shield, Layers } from 'lucide-react';
 import { useDebounce } from '@/hooks/use-debounce';
 import { apiService, ApiError } from '@/services/api';
 import {
@@ -20,10 +20,11 @@ import { normalizeAccountType, PAGE_SIZE } from './internal-utils';
 import { UsersTab } from './users-tab';
 import { IssuesTab } from './issues-tab';
 import { AttributionTab } from './attribution-tab';
+import { ExploreSnapshotsTab } from './explore-snapshots-tab';
 
 export function InternalDashboardShell() {
   const usersRequestIdRef = useRef(0);
-  const [activeTab, setActiveTab] = useState<'users' | 'issues' | 'attribution'>('users');
+  const [activeTab, setActiveTab] = useState<'users' | 'issues' | 'attribution' | 'snapshots'>('users');
 
   // ─── Users state ───────────────────────────────────────────────────
   const [userSearch, setUserSearch] = useState('');
@@ -274,7 +275,7 @@ export function InternalDashboardShell() {
   return (
     <Tabs
       value={activeTab}
-      onValueChange={(value) => setActiveTab(value as 'users' | 'issues' | 'attribution')}
+      onValueChange={(value) => setActiveTab(value as 'users' | 'issues' | 'attribution' | 'snapshots')}
       className="flex flex-col bg-background lg:flex-1 lg:min-h-0"
     >
       {/* Header */}
@@ -315,6 +316,10 @@ export function InternalDashboardShell() {
             <TabsTrigger value="attribution" className="gap-1.5 text-xs">
               <Link2 className="h-3.5 w-3.5" />
               Attribution
+            </TabsTrigger>
+            <TabsTrigger value="snapshots" className="gap-1.5 text-xs">
+              <Layers className="h-3.5 w-3.5" />
+              Explore Snapshots
             </TabsTrigger>
           </TabsList>
         </div>
@@ -384,6 +389,10 @@ export function InternalDashboardShell() {
 
           <TabsContent value="attribution">
             <AttributionTab />
+          </TabsContent>
+
+          <TabsContent value="snapshots">
+            <ExploreSnapshotsTab />
           </TabsContent>
         </div>
       </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,6 +16,8 @@ import {
   InternalAccountTypeAuditEntry,
   InternalIssuesResponse,
   InternalIssueDetail,
+  InternalExploreSnapshotsResponse,
+  InternalExploreSnapshotItemsResponse,
   InternalSignupAttributionOverview,
   InternalSignupAttributionBreakdownResponse,
   InternalSignupAttributionUsersResponse,
@@ -596,6 +598,23 @@ class ApiService {
     return this.request<InternalIssueDetail>(`/api/v1/internal/issues/${issueId}`, {
       timeoutMs: 20000,
     });
+  }
+
+  async getInternalExploreSnapshots(days = 14): Promise<InternalExploreSnapshotsResponse> {
+    return this.request<InternalExploreSnapshotsResponse>(
+      `/api/v1/internal/explore/snapshots?days=${days}`,
+      { timeoutMs: 20000 }
+    );
+  }
+
+  async getInternalExploreSnapshotItems(
+    snapshotId: string,
+    limit = 50
+  ): Promise<InternalExploreSnapshotItemsResponse> {
+    return this.request<InternalExploreSnapshotItemsResponse>(
+      `/api/v1/internal/explore/snapshots/${encodeURIComponent(snapshotId)}/items?limit=${limit}`,
+      { timeoutMs: 20000 }
+    );
   }
 
   async exportInternalUsersCsv(params: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -709,3 +709,69 @@ export interface UpdateInternalSignupLinkTemplateRequest {
   campaign?: string;
   isActive?: boolean;
 }
+
+// ─── Explore snapshot inspection (internal debugging) ───────────────────
+export interface InternalExploreSnapshotSummary {
+  snapshotId: string;
+  algorithmVersion: string;
+  status: string;
+  seed: string;
+  generatedAtUtc: string;
+  createdAtUtc: string;
+  completedAtUtc?: string | null;
+  candidateCount: number;
+  itemCount: number;
+  storedItemCount: number;
+  failureReason?: string | null;
+  isLatestSuccessful: boolean;
+  validationFatalErrors: string[];
+  validationWarnings: string[];
+  // Raw metrics object from ValidationJson (e.g. content_type_distribution); shape is intentionally open.
+  validationMetrics?: Record<string, unknown> | null;
+}
+
+export interface InternalExploreSnapshotsResponse {
+  days: number;
+  items: InternalExploreSnapshotSummary[];
+}
+
+export interface InternalExploreSnapshotItem {
+  rank: number;
+  postId: string;
+  userId?: string | null;
+  elementType: string;
+  musicElementId: string;
+  createdAtUtc: string;
+  rawScore: number;
+  finalScore: number;
+  rankReason: string;
+  title?: string | null;
+  subtitle?: string | null;
+  creatorUsername?: string | null;
+  creatorAccountType?: string | null;
+  isAvailable: boolean;
+  availability: string;
+  currentPrivacy?: string | null;
+  scoreComponents: Record<string, number>;
+  penalties: Record<string, number>;
+  boosts: Record<string, number>;
+  constraintNotes?: Record<string, unknown> | null;
+  candidateSources?: Record<string, unknown> | null;
+  playlistTitleNormalized?: string | null;
+  playlistFamilyKey?: string | null;
+  playlistFamilyConfidence?: number | null;
+  playlistFamilyReason?: string | null;
+  isGenericPlaylistFamily?: boolean | null;
+}
+
+export interface InternalExploreSnapshotItemsResponse {
+  snapshotId: string;
+  algorithmVersion: string;
+  status: string;
+  generatedAtUtc: string;
+  isLatestSuccessful: boolean;
+  totalItemCount: number;
+  returnedItemCount: number;
+  limit: number;
+  items: InternalExploreSnapshotItem[];
+}

--- a/tsconfig.unit-tests.json
+++ b/tsconfig.unit-tests.json
@@ -13,7 +13,9 @@
   },
   "include": [
     "src/utils/platform-normalization.ts",
-    "src/utils/__tests__/platform-normalization.test.ts"
+    "src/utils/__tests__/platform-normalization.test.ts",
+    "src/app/(sidebar)/internal/_components/explore-snapshot-utils.ts",
+    "src/app/(sidebar)/internal/_components/__tests__/explore-snapshot-utils.test.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Introduce an internal Explore snapshots inspection feature: new React components (explore-snapshots-tab, explore-snapshot-items-table, explore-score-breakdown) and helper utilities (explore-snapshot-utils) for rendering and formatting snapshot/score data. Add API client methods (getInternalExploreSnapshots, getInternalExploreSnapshotItems) and new types for snapshot summaries/items and responses. Wire the snapshots tab into the internal dashboard and add a unit test for the pure utils. Update tsconfig.unit-tests to include the new utils and test, and adjust package.json test:unit to clean and run compiled tests from .unit-test-dist.